### PR TITLE
Throw re.error when invalidregex is provided

### DIFF
--- a/simplematrixbotlib/config.py
+++ b/simplematrixbotlib/config.py
@@ -16,10 +16,9 @@ class Config:
         """Checks if the patterns in value are valid or throws an error"""
         for v in value:
             try:
-                re.compile(v)   # Fails for invalid regex
+                re.compile(v)  # Fails for invalid regex
             except re.error:
                 raise re.error(f"{v} is not a valid regex.")
-
 
     def _load_config_dict(self, config_dict: dict) -> None:
         for key, value in config_dict.items():
@@ -75,7 +74,7 @@ class Config:
         return self._allowlist
 
     @allowlist.setter
-    def     allowlist(self, value: Set[str]) -> None:
+    def allowlist(self, value: Set[str]) -> None:
         self._check_set_regex(value)
         self._allowlist = value
 

--- a/simplematrixbotlib/config.py
+++ b/simplematrixbotlib/config.py
@@ -85,29 +85,39 @@ class Config:
             return
         self._allowlist = checked
 
-    def add_allowlist(self, value: Set[str]) -> None:
+    def add_allowlist(self, value: Set[str]) -> bool:
         """
         Parameters
         ----------
         value : Set[str]
             A set of strings which represent Matrix IDs or a regular expression matching Matrix IDs to be added to allowlist.
+        Returns
+        -------
+        bool
+            A bool indicating if the action was successful
         """
         checked = self._check_set_regex(value)
         if checked is None:
-            return
+            return False
         self._allowlist = self._allowlist.union(checked)
+        return True
 
-    def remove_allowlist(self, value: Set[str]) -> None:
+    def remove_allowlist(self, value: Set[str]) -> bool:
         """
         Parameters
         ----------
         value : Set[str]
             A set of strings which represent Matrix IDs or a regular expression matching Matrix IDs to be removed from allowlist.
+        Returns
+        -------
+        bool
+            A bool indicating if the action was successful
         """
         checked = self._check_set_regex(value)
         if checked is None:
-            return
+            return False
         self._allowlist = self._allowlist - checked
+        return True
 
     @property
     def blocklist(self) -> Set[re.Pattern]:

--- a/simplematrixbotlib/config.py
+++ b/simplematrixbotlib/config.py
@@ -14,7 +14,11 @@ class Config:
     @staticmethod
     def _check_set_regex(value: Set[str]):
         """Checks if the patterns in value are valid or throws an error"""
-        [re.compile(v) for v in value]  # Fails for invalid regex
+        for v in value:
+            try:
+                re.compile(v)   # Fails for invalid regex
+            except re.error:
+                raise re.error(f"{v} is not a valid regex.")
 
 
     def _load_config_dict(self, config_dict: dict) -> None:
@@ -71,7 +75,7 @@ class Config:
         return self._allowlist
 
     @allowlist.setter
-    def allowlist(self, value: Set[str]) -> None:
+    def     allowlist(self, value: Set[str]) -> None:
         self._check_set_regex(value)
         self._allowlist = value
 

--- a/simplematrixbotlib/config.py
+++ b/simplematrixbotlib/config.py
@@ -87,7 +87,7 @@ class Config:
         self._check_set_regex(value)
         self._allowlist = self._allowlist.union(value)
 
-    def remove_allowlist(self, value: Set[str]) -> bool:
+    def remove_allowlist(self, value: Set[str]):
         """
         Removes all in the value set from the allowlist or throws an error
 

--- a/tests/config/sample_config_files/config5.toml
+++ b/tests/config/sample_config_files/config5.toml
@@ -1,0 +1,3 @@
+[simplematrixbotlib.config]
+allowlist = ["[."]
+blocklist = ["@test2:example\\.org"]

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -69,3 +69,14 @@ def test_manual_set():
     assert config.blocklist == set(map(re.compile, ['@test:matrix\\.org']))
     config.blocklist = {'*:example\\.org'}
     assert config.blocklist == set(map(re.compile, ['@test:matrix\\.org']))
+
+
+def test_botlib():
+    config = botlib.Config()
+    with pytest.raises(re.error):
+        config._check_set_regex(set(r"[."))
+    # Valid patterns
+    config._check_set_regex(set(r"@testuser:example.org"))
+
+    with pytest.raises(re.error):
+        config.load_toml(os.path.join(sample_config_path, 'config5.toml'))


### PR DESCRIPTION
This (breaking) change will change the behavior of adding and removing to allowlist and  blocklist. Provided with en invalid regex to add/remove the library will no longer only print an error and not change the allow and blocklist but fail with `re.error`. This enables users of the library to determine if the action was successful. This can also happen in `load_toml` as the regex patterns for allowlist and blocklist are compiled.