### PR TITLE
Add quotes

### DIFF
--- a/doc/manual/encryption.md
+++ b/doc/manual/encryption.md
@@ -16,7 +16,7 @@ More information is available at [matrix-nio](https://github.com/poljar/matrix-n
 Finally, install e2e support for matrix-nio by running:
 
 ```
-python -m pip install matrix-nio[e2e]
+python -m pip install "matrix-nio[e2e]"
 ```
 
 If there are issues installing the e2e extra with pip from PyPI, additional packages may be required to build python-olm on your distribution, for example python3-devel on openSUSE.


### PR DESCRIPTION
to avoid zsh: no matches found: matrix-nio[e2e]"