### PR TITLE
E2EE with access token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [v2.7.2](https://github.com/i10b/simplematrixbotlib/releases/tag/v2.7.2)
+##  2022-10-13 2b0474dc49
+###  Notes:
+- Encryption Support!
+### Additions:
+- None
+### Modifications
+- Fixes a bug that prevented custom event listeners from functioning properly
+### Removals:
+- None
+### Deprecations
+- None
+
 ## [v2.7.0](https://github.com/i10b/simplematrixbotlib/releases/tag/v2.7.0)
 ##  2022-08-20 a340933
 ###  Notes:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Simple-Matrix-Bot-Lib
-(Version 2.7.0)
+(Version 2.7.2)
 
 Simple-Matrix-Bot-Lib is a Python bot library for the Matrix ecosystem built on [matrix-nio](https://github.com/poljar/matrix-nio).
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,7 +22,7 @@ copyright = '2021, KrazyKirby99999'
 author = 'KrazyKirby99999'
 
 # The full version, including alpha/beta/rc tags
-release = '2.7.0'
+release = '2.7.2'
 
 # -- General configuration ---------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "simplematrixbotlib"
-version = "2.7.0"
+version = "2.7.2"
 description = "An easy to use bot library for the Matrix ecosystem written in Python."
 authors = ["krazykirby99999 <krazykirby99999@gmail.com>"]
 license = "MIT"

--- a/simplematrixbotlib/api.py
+++ b/simplematrixbotlib/api.py
@@ -138,7 +138,7 @@ class Api:
                         "Loaded device ID (session ID) does not match the access token. "
                         "Recovering automatically...")
                     self.creds.device_id, self.async_client.device_id = (
-                        user_id, user_id)
+                        device_id, device_id)
                     self.creds.session_write_file()
 
             if self.config.encryption_enabled:

--- a/simplematrixbotlib/api.py
+++ b/simplematrixbotlib/api.py
@@ -126,8 +126,8 @@ class Api:
                     f"or reset your session by deleting {self.creds._session_stored_file}"
                     f"{' and ' + self.config.store_path if self.config.encryption_enabled else ''}."
                 )
-            elif device_id != self.creds.device_id:
-                if self.config.encryption_enabled:
+            if device_id != self.creds.device_id:
+                if self.config.encryption_enabled and self.creds.device_id:
                     raise ValueError(
                         f"Given device ID (session ID) '{device_id}' does not match the access token. "
                         "This is critical, because it may break your verification status unintentionally. "


### PR DESCRIPTION
++ This pull request is not merge ready ++

## What the PR solves

This PR solves the following problem for me:

1. Create an account and obtain an access token for a bot via the admin API e.g.

```bash
$ curl -XPOST -d '{                    
    "identifier": { "type": "m.id.user", "user": "test-registration-bot" },
    "password": "mypassword",
    "type": "m.login.password",
    "device_id": "bot_testinstance"
}' 'https://synapse.example.com/_matrix/client/r0/login'

```
2. Activate E2EE for the bot 

```python
smbl_config = botlib.Config()
smbl_config.emoji_verify = True
smbl_config.ignore_unverified_devices = True
```

3. Try to run the bot fails. The problem is, that the smbl can not load the device_id from the store (as this does not yet exist) but also never updates it by asking the server (like in https://github.com/i10b/simplematrixbotlib/blob/master/simplematrixbotlib/api.py#L106). Therefore the device ID is not set and this happens.

```
Traceback (most recent call last):
  File "/home/moanos/software/matrix-registration-bot/matrix_registration_bot/bot.py", line 208, in <module>
    run_bot()
  File "/home/moanos/software/matrix-registration-bot/matrix_registration_bot/bot.py", line 200, in run_bot
    bot.run()
  File "/home/moanos/software/matrix-registration-bot/venv/lib/python3.10/site-packages/simplematrixbotlib/bot.py", line 88, in run
    asyncio.run(self.main())
  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "/home/moanos/software/matrix-registration-bot/venv/lib/python3.10/site-packages/simplematrixbotlib/bot.py", line 50, in main
    await self.api.login()
  File "/home/moanos/software/matrix-registration-bot/venv/lib/python3.10/site-packages/simplematrixbotlib/api.py", line 145, in login
    self.async_client.load_store()
  File "/home/moanos/software/matrix-registration-bot/venv/lib/python3.10/site-packages/nio/client/base_client.py", line 359, in load_store
    raise LocalProtocolError("Device id is not set")
nio.exceptions.LocalProtocolError: Device id is not set
```

## Why is this not merge ready?

I think there still is an issue with device verification that is not solved by this PR. So this can also be treated as an issue :)