### PR TITLE
add support to communicate via a proxy #167

### DIFF
--- a/simplematrixbotlib/api.py
+++ b/simplematrixbotlib/api.py
@@ -91,11 +91,13 @@ class Api:
             store_sync_tokens=True,
             encryption_enabled=self.config.encryption_enabled)
         store_path = self.config.store_path
+        proxy = self.config.proxy or os.environ.get('https_proxy',os.environ.get('HTTPS_PROXY'))
         os.makedirs(store_path, mode=0o750, exist_ok=True)
         self.async_client = AsyncClient(homeserver=self.creds.homeserver,
                                         user=self.creds.username,
                                         device_id=self.creds.device_id,
                                         store_path=store_path,
+                                        proxy=proxy,
                                         config=client_config)
 
         if self.creds.access_token:

--- a/simplematrixbotlib/config.py
+++ b/simplematrixbotlib/config.py
@@ -44,6 +44,7 @@ class Config:
     _join_on_invite: bool = True
     _encryption_enabled: bool = ENCRYPTION_ENABLED
     _emoji_verify: bool = False  # So users who enable it are aware of required interactivity
+    _proxy: str = None  # So users who enable it are aware of required interactivity
     _ignore_unverified_devices: bool = True  # True by default in Element
     # TODO: auto-ignore/auto-blacklist devices/users
     # _allowed_unverified_devices etc
@@ -119,6 +120,20 @@ class Config:
     @emoji_verify.setter
     def emoji_verify(self, value: bool) -> None:
         self._emoji_verify = value and self.encryption_enabled
+
+    @property
+    def proxy(self) -> str:
+        """
+        Returns
+        -------
+        string
+            Whether a proxy, and which should be used to communicate.
+        """
+        return self._proxy
+
+    @proxy.setter
+    def proxy(self, value: str) -> None:
+        self._proxy = value 
 
     @property
     def store_path(self) -> str:


### PR DESCRIPTION
Since nio already supports a proxy it was relatively simple to add support to communicate via a proxy which is really important behind coporate firewalls.