### PR TITLE
Enable fenced_code extenstion for markdown messages

### DIFF
--- a/simplematrixbotlib/api.py
+++ b/simplematrixbotlib/api.py
@@ -263,7 +263,9 @@ class Api:
                                   "org.matrix.custom.html",
                                   "formatted_body":
                                   markdown.markdown(message,
-                                                    extensions=['nl2br'])
+                                                    extensions=[
+                                                        'nl2br',
+                                                        'fenced_code'])
                               })
 
     async def send_image_message(self, room_id, image_filepath):


### PR DESCRIPTION
Hi,

I created a small bot using this lib. I needed to have the `fenced_code` markdown extension enabled. 

I do not see any reason not to enable it, so I thought I would create this PR :)

Cheers,